### PR TITLE
:clamp: Add BigInt Compress Functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "const_panic"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7782af8f90fe69a4bb41e460abe1727d493403d8b2cc43201a3a3e906b24379f"
+checksum = "013b6c2c3a14d678f38cd23994b02da3a1a1b6a5d1eedddfe63a5a5f11b13a81"
 
 [[package]]
 name = "crypto-common"

--- a/src/bigint/cmpeq/mod.rs
+++ b/src/bigint/cmpeq/mod.rs
@@ -168,6 +168,12 @@ where
     {
         T::OP_EXTEND::<Q>()
     }
+    fn OP_COMPRESS<Q>() -> Script
+    where
+        Q: NonNativeLimbInteger,
+    {
+        T::OP_COMPRESS::<Q>()
+    }
 }
 
 #[allow(non_snake_case)]

--- a/src/bigint/implementation.rs
+++ b/src/bigint/implementation.rs
@@ -167,4 +167,10 @@ impl<const N_BITS: usize, const LIMB_SIZE: usize> NonNativeInteger
     {
         Self::handle_OP_EXTEND::<T>()
     }
+    fn OP_COMPRESS<T>() -> Script
+    where
+        T: NonNativeLimbInteger,
+    {
+        Self::handle_OP_COMPRESS::<T>()
+    }
 }

--- a/src/bigint/naf/implementation.rs
+++ b/src/bigint/naf/implementation.rs
@@ -85,7 +85,7 @@ pub fn binary_to_be_naf(num_bits: usize) -> Script {
             OP_2DUP OP_BITAND OP_IF
                 // In case they are both 1, we need to change them to -1 and 0, while the carry must be one
                 OP_3DROP
-                1 (-1) 0
+                { 1 } { -1 } { 0 }
             OP_ENDIF
 
             OP_ROT

--- a/src/bigint/naf/implementation.rs
+++ b/src/bigint/naf/implementation.rs
@@ -85,7 +85,7 @@ pub fn binary_to_be_naf(num_bits: usize) -> Script {
             OP_2DUP OP_BITAND OP_IF
                 // In case they are both 1, we need to change them to -1 and 0, while the carry must be one
                 OP_3DROP
-                1 -1 0
+                1 (-1) 0
             OP_ENDIF
 
             OP_ROT

--- a/src/bigint/stack/implementation.rs
+++ b/src/bigint/stack/implementation.rs
@@ -207,7 +207,7 @@ impl<const N_BITS: usize, const LIMB_SIZE: usize> NonNativeBigIntImpl<N_BITS, LI
         }
     }
 
-    /// Extends the big integer to the specified type.
+    /// Extends the big integer to the specified [`NonNativeLimbInteger`].
     pub(in super::super) fn handle_OP_EXTEND<T>() -> Script
     where
         T: NonNativeLimbInteger,
@@ -238,7 +238,7 @@ impl<const N_BITS: usize, const LIMB_SIZE: usize> NonNativeBigIntImpl<N_BITS, LI
         }
     }
 
-    /// Extends the big integer to the specified type.
+    /// Compresses the big integer to the specified [`NonNativeLimbInteger`].
     pub(in super::super) fn handle_OP_COMPRESS<T>() -> Script
     where
         T: NonNativeLimbInteger,

--- a/src/bigint/stack/implementation.rs
+++ b/src/bigint/stack/implementation.rs
@@ -221,6 +221,7 @@ impl<const N_BITS: usize, const LIMB_SIZE: usize> NonNativeBigIntImpl<N_BITS, LI
             "The integers to be extended must have the same number of bits in limb"
         );
 
+        // Calculating the number of limbs to add
         let n_limbs_self = (Self::N_BITS + Self::LIMB_SIZE - 1) / Self::LIMB_SIZE;
         let n_limbs_extension = (T::N_BITS + T::LIMB_SIZE - 1) / T::LIMB_SIZE;
         let n_limbs_add = n_limbs_extension - n_limbs_self;
@@ -233,6 +234,36 @@ impl<const N_BITS: usize, const LIMB_SIZE: usize> NonNativeBigIntImpl<N_BITS, LI
             { OP_CLONE(0, n_limbs_add) } // Pushing zeros to the stack
             for _ in 0..n_limbs_self {
                 { n_limbs_extension - 1 } OP_ROLL
+            }
+        }
+    }
+
+    /// Extends the big integer to the specified type.
+    pub(in super::super) fn handle_OP_COMPRESS<T>() -> Script
+    where
+        T: NonNativeLimbInteger,
+    {
+        assert!(
+            T::N_BITS < Self::N_BITS,
+            "The integer to be compressed to must have less bits than the current integer"
+        );
+        assert!(
+            T::LIMB_SIZE == Self::LIMB_SIZE,
+            "The integers to be compressed to must have the same number of bits in limb"
+        );
+
+        // Calculating the number of limbs to remove
+        let n_limbs_self = (Self::N_BITS + Self::LIMB_SIZE - 1) / Self::LIMB_SIZE;
+        let n_limbs_compress = (T::N_BITS + T::LIMB_SIZE - 1) / T::LIMB_SIZE;
+        let n_limbs_to_remove = n_limbs_self - n_limbs_compress;
+
+        if n_limbs_to_remove == 0 {
+            return script! {};
+        }
+
+        script! {
+            for i in 0..n_limbs_to_remove {
+                { Self::N_LIMBS - i - 1 } OP_ROLL OP_DROP
             }
         }
     }

--- a/src/bigint/stack/test.rs
+++ b/src/bigint/stack/test.rs
@@ -488,3 +488,26 @@ fn test_254_bit_widening() {
         assert!(exec_result.success);
     }
 }
+
+#[test]
+/// Tests the extension of 254-bit number to 508-bit number and then
+/// compressing it back to 254-bit number.
+fn test_254_bit_compress() {
+    print_script_size("254-bit compression", U508::OP_COMPRESS::<U254>());
+
+    let mut prng = ChaCha20Rng::seed_from_u64(0);
+    for _ in 0..100 {
+        let a: BigUint = prng.sample(RandomBits::new(254));
+        let script = script! {
+            { U254::OP_PUSH_U32LESLICE(&a.to_u32_digits()) }
+            { U254::OP_EXTEND::<U508>() }
+            { U508::OP_COMPRESS::<U254>() }
+            { U254::OP_PUSH_U32LESLICE(&a.to_u32_digits()) }
+            { U254::OP_EQUALVERIFY(1, 0) }
+            OP_TRUE
+        };
+
+        let exec_result = execute_script(script);
+        assert!(exec_result.success);
+    }
+}

--- a/src/bigint/window/mod.rs
+++ b/src/bigint/window/mod.rs
@@ -204,6 +204,12 @@ where
     {
         T::OP_EXTEND::<Q>()
     }
+    fn OP_COMPRESS<Q>() -> Script
+    where
+        Q: NonNativeLimbInteger,
+    {
+        T::OP_COMPRESS::<Q>()
+    }
 }
 
 #[allow(non_snake_case)]

--- a/src/bigint/window/precompute.rs
+++ b/src/bigint/window/precompute.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use crate::traits::integer::NonNativeLimbInteger;
 use crate::treepp::*;
 
-pub(in super::super) struct WindowedPrecomputeTable<T, const WIDTH: usize, const NOOVERFLOW: bool>
+pub struct WindowedPrecomputeTable<T, const WIDTH: usize, const NOOVERFLOW: bool>
 where
     T: NonNativeLimbInteger,
 {

--- a/src/traits/integer.rs
+++ b/src/traits/integer.rs
@@ -46,6 +46,11 @@ pub trait NonNativeInteger: Comparable + Arithmeticable + Bitable {
     where
         T: NonNativeLimbInteger;
 
+    /// Compresses the given [`NonNativeInteger`] back to the specified type.
+    fn OP_COMPRESS<T>() -> Script
+    where
+        T: NonNativeLimbInteger;
+
     // --- Stack operations ---
 
     /// Zips two [`NonNativeInteger`]s at specified depths.


### PR DESCRIPTION
# Objective

This PR adds the method for `BigInt` to be compressed to the lower-limb representation (by cutting the top most significant bits). This method might come in handy for some future optimizations. 

Additionally, we make `WindowedPrecomputeTable` public.